### PR TITLE
Add Windows Terminal theme

### DIFF
--- a/terminal/mysticaltutor-windowsterminal.json
+++ b/terminal/mysticaltutor-windowsterminal.json
@@ -4,9 +4,21 @@
 
 {
     "schemes": [{
+                    "name" : "Mystical Tutor",
+
+                    "cursorColor" : "#d9d9d9",
+                    
                     "background" : "#1e2227",
+                    "foreground" : "#d9d9d9",
+                    
                     "black" : "#1e2227",
                     "blue" : "#5c8ec7",
+                    "cyan" : "#5cbe97",
+                    "green" : "#8bbe67",
+                    "purple" : "#8b5fc7",
+                    "red" : "#e07093",
+                    "white" : "#d9d9d9",
+                    "yellow" : "#bb8e67",
                     "brightBlack" : "#30343c",
                     "brightBlue" : "#a0b4cf",
                     "brightCyan" : "#a0c4bd",
@@ -14,14 +26,6 @@
                     "brightPurple" : "#b1a3df",
                     "brightRed" : "#dfb4c9",
                     "brightWhite" : "#ffffff",
-                    "brightYellow" : "#c3b470",
-                    "cyan" : "#5cbe97",
-                    "foreground" : "#d9d9d9",
-                    "green" : "#8bbe67",
-                    "name" : "Mystical Tutor",
-                    "purple" : "#8b5fc7",
-                    "red" : "#e07093",
-                    "white" : "#d9d9d9",
-                    "yellow" : "#bb8e67"
+                    "brightYellow" : "#c3b470"
                 }]
 }

--- a/terminal/mysticaltutor-windowsterminal.json
+++ b/terminal/mysticaltutor-windowsterminal.json
@@ -1,0 +1,27 @@
+// To use, copy scheme from "schemes" array into the corresponding array in your
+// settings.json file for Windows Terminal, and set the "colorScheme" field to
+// "Mystical Tutor" for whichever profile(s) you want to use the color scheme.
+
+{
+    "schemes": [{
+                    "background" : "#1e2227",
+                    "black" : "#1e2227",
+                    "blue" : "#5c8ec7",
+                    "brightBlack" : "#30343c",
+                    "brightBlue" : "#a0b4cf",
+                    "brightCyan" : "#a0c4bd",
+                    "brightGreen" : "#b1c6ac",
+                    "brightPurple" : "#b1a3df",
+                    "brightRed" : "#dfb4c9",
+                    "brightWhite" : "#ffffff",
+                    "brightYellow" : "#c3b470",
+                    "cyan" : "#5cbe97",
+                    "foreground" : "#d9d9d9",
+                    "green" : "#8bbe67",
+                    "name" : "Mystical Tutor",
+                    "purple" : "#8b5fc7",
+                    "red" : "#e07093",
+                    "white" : "#d9d9d9",
+                    "yellow" : "#bb8e67"
+                }]
+}


### PR DESCRIPTION
This is a port for Windows Terminal. I mapped colors from the .minttyrc file, with the following assumptions:
- Bold* colors mapped to bright*
- Magenta colors mapped to purple colors

Windows Terminal theme documentation can be  found [here](https://docs.microsoft.com/en-us/windows/terminal/customize-settings/color-schemes).

I was unsure on how to name the file. The Windows Terminal config file is settings.json. I kept the theme name and the extension as the other terminal files do, but added '-windowsterminal' to the file name to indicate the target terminal, since the extension doesn't help with that.